### PR TITLE
Don't set geometry=None in open_boutdataset

### DIFF
--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -30,7 +30,6 @@ def open_hermesdataset(
     ds = open_boutdataset(
         datapath=datapath,
         inputfilepath=inputfilepath,
-        geometry=None,
         chunks=chunks,
         run_name=run_name,
         info=False,


### PR DESCRIPTION
Setting geometry in xhermes.open was broken because the geometry keyword was then set twice.