### PR TITLE
Use attributes in data if already set

### DIFF
--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -56,12 +56,10 @@ class HermesDataArrayAccessor(BoutDataArrayAccessor):
         """
         units_type = self.data.attrs.get("units_type", "unknown")
 
-        if units_type == "unknown":
-            return
-        elif units_type == "SI":
+        if units_type == "SI":
             # already un-normalised
             return
-        elif units_type == "hermes":
+        elif ("units" in self.data.attrs) and ("conversion" in self.data.attrs)
             # Normalise using values
             self.data *= self.data.attrs["conversion"]
             self.data.attrs["units_type"] = "SI"

--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -55,8 +55,15 @@ def open_hermesdataset(
 
     for varname in ds:
         da = ds[varname]
-        if len(da.dims) == 4:
-            # 4D field => Mark as Hermes-normalised data
+        if len(da.dims) == 4:  # Time-evolving field
+            da.attrs["units_type"] = "hermes"
+
+            # Check if data already has units and conversion attributes
+            if ("units" in da.attrs) and ("conversion" in da.attrs):
+                print(varname + " already annotated")
+                continue  # No need to add attributes
+
+            # Mark as Hermes-normalised data
             da.attrs["units_type"] = "hermes"
 
             if varname[:2] == "NV":
@@ -168,7 +175,14 @@ def open(
     import xhermes
     ds = xhermes.open('data')
     ```
-    where 'data' is a directory
+    where 'data' is a directory.
+
+    Can also load a grid file containing geometry information:
+
+    Example:
+    ```
+    bd = xhermes.open(".", geometry="toroidal", gridfilepath="../tokamak.nc")
+    ```
 
     Parameters
     ----------


### PR DESCRIPTION
New version of Hermes will add attributes to many output variables. If these are set then don't override, and use to unnormalise.