### PR TITLE
Add various geometry extraction features and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # xHermes
 
-Extends [xBOUT](https://github.com/boutproject/xBOUT) with routines specific to
-the [Hermes-3](https://github.com/bendudson/hermes-3) model.
+xHermes a wrapper around [xBOUT](https://github.com/boutproject/xBOUT) to provide [Hermes-3](https://github.com/bendudson/hermes-3) specific 
+features. Both use [Xarray](https://docs.xarray.dev/en/stable/) which provides a scalable and powerful framework
+for dealing with large amounts of data while preserving dimensional 
+consistency.
+
+While Xarray is based on Numpy arrays under the hood and the data 
+can be accessed in this way, Xarray's main benefit comes in its
+powerful abilities to select, filter and operate on data. The 
+syntax is similar to Pandas and the basics are explained in 
+Xarray's excellent documentation.
+If you are new to Xarray, it may be useful to start with reviewing the [selection syntax](https://docs.xarray.dev/en/stable/user-guide/indexing.html).
+
+## Loading simulations
 
 The data from a Hermes-3 run can be loaded with just
 
     import xhermes
-    bd = xhermes.open('./data/')
+    ds = xhermes.open(hermes_simulation_path)
 
 where the `data` directory is assumed to contain the `BOUT.dmp.*.nc`
 files and a `BOUT.settings` file. `open` returns an instance of an
@@ -14,4 +25,67 @@ files and a `BOUT.settings` file. `open` returns an instance of an
 in the `attrs`, so represents a general structure for storing all of
 the output of a simulation, including data, input options and (soon)
 grid data.
+
+When working with 2D or 3D simulations of tokamaks, it can be useful to 
+load the grid along with the simulation file and pass the "toroidal" flag to xBOUT:
+
+    import xhermes
+    ds = xhermes.open(hermes_simulation_path, gridfilepath = grid_file_path, geometry = "toroidal")
+
+This loads the metric tensor and grid corner coordinates from the grid which
+enables geometrical operations, polygonal plotting routines and additional metadata on topology.
+
+## Working with the data
+
+### Normalisation and geometry extraction
+
+All variables within Hermes-3 are normalised. The normalisation factors, the units and variable names 
+are provided in the Hermes-3 output for most variables. 
+This information can be accessed for each variable DataArray:
+
+    ds["Pe"].attrs
+
+xHermes automatically applies the unnormalisation when the simulation is loaded in.
+
+When working with 1D and 2D tokamak simulations, it can be useful to extract 
+cell lengths, volumes and cross-sectional areas as well as some additional metadata from the model:
+
+    ds = ds.hermes.extract_1D_tokamak_geometry()
+
+or
+
+    ds = ds.hermes.extract_2D_tokamak_geometry()
+
+### The Dataset
+
+The Dataset `ds` contains useful objects:
+- A DataArray for each variable: `ds.data_vars` shows a list. `ds["Pe"]` returns the Pe DataArray.
+- A DataArray for each coordinate: `ds.coords` shows a list. `ds["t"]` or `ds.coords["t"]` returns the t DataArray.
+- A summary of dimensions in the model: `ds.dims`
+- Model metadata: `ds.metadata`
+- Model input settings: `ds.options`
+
+### The DataArray
+
+The DataArray (e.g. `ds["Pe"]`) contains the array with the variable data, its dimensionality and
+attributes as well as metadata and options inherited from the parent dataset.
+
+A visual summary of the DataArray contents and size can be obtained by simply:
+
+    ds["Pe"]
+
+Note that this may be slow due to the Xarray overhead. To access the underlying data as a Numpy array, one can use:
+
+    ds["Pe"].values
+
+or
+
+    ds["Pe"].data
+
+### Plotting
+Xarray contains a lot of built-in plotting routines which can be used to prepare [excellent 1D and 2D plots](https://docs.xarray.dev/en/stable/user-guide/plotting.html).
+Unfortunately, it is unable to deal with 2D plots in tokamak geometry.
+Routines to plot those are available in xBOUT which has some excellent [example notebooks](https://github.com/boutproject/xBOUT-examples).
+
+
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The data from a Hermes-3 run can be loaded with just
     import xhermes
     ds = xhermes.open(hermes_simulation_path)
 
-where the `data` directory is assumed to contain the `BOUT.dmp.*.nc`
+where the `hermes_simulation_path` directory is assumed to contain the `BOUT.dmp.*.nc`
 files and a `BOUT.settings` file. `open` returns an instance of an
 `xarray.Dataset` which contains BOUT- and Hermes-specific information
 in the `attrs`, so represents a general structure for storing all of

--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -95,6 +95,123 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
             "long_name" : "Cell Volume"})
         
         return ds
+    
+    def extract_2d_tokamak_geometry(self):
+        """
+        Process the results to generate 2D relevant geometry data:
+        
+        Calculates
+        ----------
+        - nxg and nyg, versions of ny and nx which always include guard cells 
+          if they exist in the dataset, and do not include them if they don't
+        - j1_1g, j1_2g, ..., versions of jyseps which account for guards in the 
+          same way as nxg and nyg
+        - x_idx, y_idx: arrays of radial and poloidal indices of all cells
+        - dv, dr, dthe, dl: cell volume and real space cell dimensions
+        - Adds target names to the metadata accounting for single or double null
+        
+        Notes
+        ----------
+        - Adds copies of jyseps1_1 that are shortened to j1_1 etc. 
+          This is potentially annoying.
+        - The reason it's useful to have arrays of coordinate indices
+          is because Xarray is surprisingly awkward when it comes to 
+          obtaining this from the coordinates.
+        - This method has a hardcoded requirement for providing the grid file.
+          
+        Returns
+        ----------
+        - Dataset with the new geometry 
+        """
+        
+        ds = self.data.squeeze()
+        m = ds.metadata
+        
+        if "topology" not in m:
+            raise Exception(
+                "2D Tokamak topology missing from metadata. Please load model with the flag geometry = 'toroidal' and provide grid")
+        
+        # Add theta index to coords so that both X and theta can be accessed index-wise
+        # It is surprisingly hard to extract the index of coordinates in Xarray...
+        ds.coords["theta_idx"] = (["theta"], range(len(ds.coords["theta"])))
+        
+        # Extract target names. This is done here and not in load because load is not 
+        # tokamak specific.
+        if "single-null" in m["topology"]:
+            m["targets"] = ["inner_lower", "outer_lower"]
+        elif "double-null" in m["topology"]:
+            m["targets"] = ["inner_lower", "outer_lower", "inner_upper", "outer_upper"]
+            
+        num_targets = len(m["targets"])
+
+        # nyg, nxg: cell counts which are always with guard cells 
+        # if they exist, or not if they don't
+        if m["keep_xboundaries"] == 0:
+            m["nxg"] = m["nx"] - m["MXG"] * 2 
+            m["MXG"] = 0
+        else:
+            m["nxg"] = m["nx"]
+            
+        if m["keep_yboundaries"] == 0:
+            m["nyg"] = m["ny"]    
+            m["MYG"] = 0
+        else:
+            m["nyg"] = m["ny"] + m["MYG"] * num_targets   
+        
+        # Simplified names of the separatrix indices          
+        m["j1_1"] = m["jyseps1_1"]
+        m["j1_2"] = m["jyseps1_2"]
+        m["j2_1"] = m["jyseps2_1"]
+        m["j2_2"] = m["jyseps2_2"]
+        
+        # Separatrix indices which account for guard cells in the same way as nxg, nyg
+        m["j1_1g"] = m["j1_1"] + m["MYG"]
+        m["j1_2g"] = m["j1_2"] + m["MYG"] * (num_targets - 1)
+        m["j2_1g"] = m["j2_1"] + m["MYG"]
+        m["j2_2g"] = m["j2_2"] + m["MYG"] * (num_targets - 1)
+            
+        # Array of radial (x) indices and of poloidal (y) indices for each cell
+        # This is useful because Xarray makes it awkward to extract indices in certain cases
+        ds["x_idx"] = (["x", "theta"], np.array([np.array(range(m["nxg"]))] * int(m["nyg"])).transpose())
+        ds["y_idx"] = (["x", "theta"], np.array([np.array(range(m["nyg"]))] * int(m["nxg"])))
+        
+        # Cell volume calculation
+        ds["dv"] = (["x", "theta"], ds["dx"].data * ds["dy"].data * ds["dz"].data * ds["J"].data)
+        ds["dv"].attrs.update({
+            "conversion" : 1,
+            "units" : "m3",
+            "standard_name" : "cell volume",
+            "long_name" : "Cell volume",
+            "source" : "xHermes"})
+        
+        # Cell areas in real space - comes from Jacobian
+        # Note: can be calculated from flux space or real space coordinates:
+        # dV = (hthe/Bpol) * (R*Bpol*dr) * dy*2pi = hthe * dy * dr * 2pi * R
+        ds["dr"] = (["x", "theta"], ds.dx.data / (ds.R.data * ds.Bpxy.data))
+        ds["dr"].attrs.update({
+            "conversion" : 1,
+            "units" : "m",
+            "standard_name" : "radial length",
+            "long_name" : "Length of cell in the radial direction",
+            "source" : "xHermes"})
+        
+        ds["hthe"] = (["x", "theta"], ds["J"].data * ds["Bpxy"].data)    # h_theta
+        ds["hthe"].attrs.update({
+            "conversion" : 1,
+            "units" : "m/radian",
+            "standard_name" : "h_theta: poloidal arc length per radian",
+            "long_name" : "h_theta: poloidal arc length per radian",
+            "source" : "xHermes"})
+        
+        ds["dl"] = (["x", "theta"], ds["dy"].data * ds["hthe"].data)    # poloidal arc length
+        ds["dl"].attrs.update({
+            "conversion" : 1,
+            "units" : "m",
+            "standard_name" : "poloidal arc length",
+            "long_name" : "Poloidal arc length",
+            "source" : "xHermes"})
+        
+        return ds
 
 
 @register_dataarray_accessor("hermes")

--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -1,5 +1,6 @@
 from xarray import register_dataset_accessor, register_dataarray_accessor
 from xbout import BoutDatasetAccessor, BoutDataArrayAccessor
+import numpy as np
 
 
 @register_dataset_accessor("hermes")
@@ -36,6 +37,64 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
                 self.data[coord].attrs["units_type"] = "SI"
             else:
                 raise ValueError("Unrecognised units_type: " + units_type)
+            
+    def extract_1d_tokamak_geometry(self):
+        """
+        Process the results to generate 1D relevant geometry data:
+        - Reconstruct pos, the cell position in [m] from upstream from dy
+        - Calculate cross-sectional area da and volume dv
+
+        Notes
+        ----------
+        - dy is technically in flux space, but in 1D 
+          this is the same as in regular space and in units of [m]
+          
+        Returns
+        ----------
+        - Dataset with the new geometry 
+        """
+        ds = self.data.squeeze() # Get rid of 1-length dimensions
+
+        # Reconstruct grid position (pos, as in position) from dy
+        dy = ds.coords["dy"].values
+        n = len(dy)
+        pos = np.zeros(n)
+        pos[0] = -0.5*dy[1]
+        pos[1] = 0.5*dy[1]
+
+        for i in range(2,n):
+            pos[i] = pos[i-1] + 0.5*dy[i-1] + 0.5*dy[i]
+
+        # Guard replace to get position at boundaries
+        pos[-2] = (pos[-3] + pos[-2])/2
+        pos[1] = (pos[1] + pos[2])/2 
+
+        # Set 0 to be at first cell boundary in domain
+        pos = pos - pos[1]
+        ds["pos"] = (["y"], pos)
+        
+        # Make pos the main coordinate instead of y
+        ds = ds.swap_dims({"y":"pos"})
+        ds.coords["pos"].attrs = ds.coords["y"].attrs
+
+        # Derive and append metadata for the cross-sectional area
+        # and volume. The conversions are 1 because the derivation
+        # is from already-normalised parameters
+        ds["da"] = ds.J / np.sqrt(ds.g_22)
+        ds["da"].attrs.update({
+            "conversion" : 1,
+            "units" : "m2",
+            "standard_name" : "cross-sectional area",
+            "long_name" : "Cell parallel cross-sectional area"})
+        
+        ds["dv"] = ds.J * ds.dy
+        ds["dv"].attrs.update({
+            "conversion" : 1,
+            "units" : "m3",
+            "standard_name" : "cell volume",
+            "long_name" : "Cell Volume"})
+        
+        return ds
 
 
 @register_dataarray_accessor("hermes")

--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -10,6 +10,7 @@ def open_hermesdataset(
     run_name=None,
     info=True,
     unnormalise=True,
+    debug_variable_names = False,
     **kwargs,
 ):
     """
@@ -60,7 +61,8 @@ def open_hermesdataset(
 
             # Check if data already has units and conversion attributes
             if ("units" in da.attrs) and ("conversion" in da.attrs):
-                print(varname + " already annotated")
+                if debug_variable_names is True:
+                    print(varname + " already annotated")
                 continue  # No need to add attributes
 
             # Mark as Hermes-normalised data

--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -44,17 +44,15 @@ def open_hermesdataset(
     rho_s0 = meta["rho_s0"]
     Nnorm = meta["Nnorm"]
     Tnorm = meta["Tnorm"]
+    Bnorm = meta["Bnorm"]
 
     # SI values
     Mp = 1.67e-27  # Proton mass
     e = 1.602e-19  # Coulombs
 
-    # Coordinates
-    ds.t.attrs["units_type"] = "hermes"
-    ds.t.attrs["units"] = "s"
-    ds.t.attrs["conversion"] = 1.0 / Omega_ci
 
-    for varname in ds:
+
+    for varname in list(ds.data_vars) + list(ds.coords):
         da = ds[varname]
         if len(da.dims) == 4:  # Time-evolving field
             da.attrs["units_type"] = "hermes"
@@ -134,6 +132,70 @@ def open_hermesdataset(
             else:
                 # Don't know what this is
                 da.attrs["units_type"] = "unknown"
+
+                
+                
+        # Coordinates
+        if varname == "dy":
+            # Poloidal cell angular width
+            da.attrs.update(
+                {
+                    "units": "radian",
+                    "conversion": 1,
+                    "standard_name": "poloidal cell angular width",
+                    "long_name": "Poloidal cell angular width",
+                }
+            )
+        elif varname == "dx":
+            # Radial cell width
+            da.attrs.update(
+                {
+                    "units": "Wb",
+                    "conversion": rho_s0**2 * Bnorm,
+                    "standard_name": "radial cell width",
+                    "long_name": "Radial cell width in flux space",
+                }
+            )
+        elif varname == "J":
+            # Jacobian
+            da.attrs.update(
+                {
+                    "units": "m/radian T",
+                    "conversion": rho_s0 / Bnorm,
+                    "standard_name": "Jacobian",
+                    "long_name": "Jacobian to translate from flux to cylindrical coordinates in real space",
+                }
+            )
+        elif varname == "g_22":
+            # Metric tensor term
+            da.attrs.update(
+                {
+                    "units": "m2",
+                    "conversion": rho_s0**2,
+                    "standard_name": "g_22",
+                    "long_name": "g_22 term in the metric tensor",
+                }
+            )
+        elif varname == "g11":
+            # Metric tensor term
+            da.attrs.update(
+                {
+                    "units": "T-2m-2",
+                    "conversion": (Bnorm * rho_s0)**2,
+                    "standard_name": "g11",
+                    "long_name": "g11 term in the metric tensor",
+                }
+            )
+        elif varname == "t":
+            # Time
+            da.attrs.update(
+                {
+                    "units": "s",
+                    "conversion": 1/Omega_ci,
+                    "standard_name": "time",
+                    "long_name": "Time",
+                }
+            )
 
     if unnormalise:
         ds.hermes.unnormalise()


### PR DESCRIPTION
- Adds unnormalisation of most useful coordinates
- Detects species, target names and species recycle pairs and adds them to metadata
- Adds individual 1D and 2D accessors to extract geometry
- 1D method prepares a parallel distance coordinate `pos` where pos = 0 [m] at the target and makes it the main coordinate
- 2D method parses various grid metadata and adds extra coordinates that make handling geometry easier
- Both methods calculate cell cross-sectional areas and volumes in SI units
- Note that neither method is in-place
- Turns off prints for checking if variables have been annotated by default
- Based on https://github.com/mikekryjak/sdtools/tree/reorganise/hermes3