### PR TITLE
Fix bug preventing loading cases with 1 timestep

### DIFF
--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -231,7 +231,7 @@ def open_hermesdataset(
         
         # Identify dimensions
         dims = list(ds.squeeze().dims)
-        dims.remove("t")
+        if "t" in dims: dims.remove("t")
         meta["dimensions"] = len(dims)
         
         # Identify species


### PR DESCRIPTION
The line identifying the dimensionality of the simulation was assuming that the "t" dimension was always available. This caused a crash when it wasn't available, for example when there was only one timestep in the simulation.