### PR TITLE
Ensure cell widths get unnormalised

### DIFF
--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -237,9 +237,6 @@ class HermesDataArrayAccessor(BoutDataArrayAccessor):
             return
         elif ("units" in self.data.attrs) and ("conversion" in self.data.attrs):
             # Normalise using values
-            # print(self.data.name)
-            # if self.data.name == "dx":
-                # print("*"*20)
             self.data *= self.data.attrs["conversion"]
             self.data.attrs["units_type"] = "SI"
         return self

--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -25,7 +25,7 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
             da.hermes.unnormalise()
 
         # Un-normalise coordinates
-        for coord in ["t"]:
+        for coord in ["dx", "dy", "dz", "t"]:
             units_type = self.data[coord].attrs.get("units_type", "unknown")
             if (units_type == "unknown") or (units_type == "SI"):
                 continue
@@ -237,6 +237,9 @@ class HermesDataArrayAccessor(BoutDataArrayAccessor):
             return
         elif ("units" in self.data.attrs) and ("conversion" in self.data.attrs):
             # Normalise using values
+            # print(self.data.name)
+            # if self.data.name == "dx":
+                # print("*"*20)
             self.data *= self.data.attrs["conversion"]
             self.data.attrs["units_type"] = "SI"
         return self

--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -157,6 +157,17 @@ def open_hermesdataset(
                     "long_name": "Radial cell width in flux space",
                 }
             )
+        elif varname == "dz":
+            # Radial cell width
+            da.attrs.update(
+                {
+                    "units_type": "SI",
+                    "units": "radian",
+                    "conversion": 1,
+                    "standard_name": "toroidal cell angular width",
+                    "long_name": "Poloidal cell angular width",
+                }
+            )
         elif varname == "J":
             # Jacobian
             da.attrs.update(


### PR DESCRIPTION
Adds `dx`, `dy` and `dz` to the list of coords to be unnormalised. The calculation of `dv` has been incorrect because it was relying on this having been done. `dy` and `dz` are angles and don't actually need normalisation but are included for consistency and clarity.