### PR TITLE
Add guard replacement for all 1D variables

### DIFF
--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -38,7 +38,7 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
             else:
                 raise ValueError("Unrecognised units_type: " + units_type)
             
-    def extract_1d_tokamak_geometry(self, remove_outer = True):
+    def extract_1d_tokamak_geometry(self, remove_outer = False):
         """
         Process the results to generate 1D relevant geometry data:
         - Reconstruct pos, the cell position in [m] from upstream from dy
@@ -64,7 +64,13 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
 
         for i in range(1,n):
             pos[i] = pos[i-1] + 0.5*dy[i-1] + 0.5*dy[i]
-        pos -= (pos[1] + pos[2]) / 2     # Set 0 to be at first cell boundary in domain
+            
+        # Set 0 to be at first cell boundary in domain
+        if remove_outer is True:
+            pos -= (pos[2] + pos[3]) / 2     
+        else:
+            pos -= (pos[1] + pos[2]) / 2   
+        
 
         ds["pos"] = (["y"], pos)
         
@@ -74,7 +80,7 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
 
         # Get rid of outer guard cells as they aren't used
         # Solves issue when final dy is negative
-        if "outer_guards_removed" not in ds.metadata.keys():
+        if remove_outer is True and "outer_guards_removed" not in ds.metadata.keys():
             ds = ds.isel(pos = slice(1,-1))
             ds.metadata["outer_guards_removed"] = True
             

--- a/xhermes/accessors.py
+++ b/xhermes/accessors.py
@@ -59,14 +59,12 @@ class HermesDatasetAccessor(BoutDatasetAccessor):
         dy = ds.coords["dy"].values
         n = len(dy)
         pos = np.zeros(n)
-        pos[0] = -0.5*dy[1]
-        pos[1] = 0.5*dy[1]
+        pos[0] = 0.5*dy[0]
 
-        for i in range(2,n):
+        for i in range(1,n):
             pos[i] = pos[i-1] + 0.5*dy[i-1] + 0.5*dy[i]
+        pos -= (pos[1] + pos[2]) / 2     # Set 0 to be at first cell boundary in domain
 
-        # Set 0 to be at first cell boundary in domain
-        pos = pos - pos[1]
         ds["pos"] = (["y"], pos)
         
         # Make pos the main coordinate instead of y

--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -36,6 +36,17 @@ def open_hermesdataset(
         info=info,
         **kwargs,
     )
+    
+    # Record if guard cells read in or not
+    if "keep_xboundaries" in kwargs:
+        ds.metadata["keep_xboundaries"] = kwargs[flag]
+    else:
+        ds.metadata["keep_xboundaries"] = True   # Default
+        
+    if "keep_yboundaries" in kwargs:
+        ds.metadata["keep_yboundaries"] = kwargs[flag]
+    else:
+        ds.metadata["keep_yboundaries"] = True   # Default
 
     # Normalisation
     meta = ds.attrs["metadata"]

--- a/xhermes/utils.py
+++ b/xhermes/utils.py
@@ -1,0 +1,44 @@
+import xarray
+
+def guard_replace_1d(da):
+    """
+    Replace the inner guard cells with the values of their respective
+    cell edges, i.e. the values at the model inlet and at the target.
+    This is done by interpolating the value between the two neighbouring
+    cell centres. Checks for presence of guard cells if passed a DataArray.
+
+    Cell order at target:
+    ... | last | guard | second guard (unused)
+                ^target      
+        |  -3  |  -2   |      -1
+        
+    Parameters
+    ----------
+    - da: Numpy array or Xarray DataArray with guard cells
+        
+    Returns
+    ----------
+    - Numpy array with guard replacement
+
+    """
+
+    da = da.copy()
+    
+    if type(da) == xarray.core.dataarray.DataArray:
+        if da.metadata["keep_yboundaries"] is False:
+            raise ValueError("Cannot guard replace if y-boundaries are not kept")
+        
+        if da.name in da.coords:
+            raise ValueError("Cannot guard replace DataArray if it is a coordinate, try passing da.values() instead")
+        
+        da[{"pos" : -2}] = (da[{"pos" : -2}] + da[{"pos" : -3}])/2
+        da[{"pos" : 1}] = (da[{"pos" : 1}] + da[{"pos" : 2}])/2
+        
+        da = da.isel(pos = slice(1, -1))
+        
+    else:
+        da[-2] = (da[-2] + da[-3])/2
+        da[1] = (da[1] + da[2])/2
+        da = da[1:-1]
+
+    return da


### PR DESCRIPTION
Resolves https://github.com/boutproject/xhermes/issues/6.

- Makes sure y position guard replacement is done only if guard replacement is on
- Corrects position calculation so that it's zero at the domain boundary