### PR TITLE
Publish to pypi action

### DIFF
--- a/.github/workflows/pub_to_pypi.yml
+++ b/.github/workflows/pub_to_pypi.yml
@@ -1,0 +1,67 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package to PyPI
+
+# Run on GitHub release
+# The PyPI url uses the version from setup.py; it's up to the releaser to make sure the release label/tag matches!
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build dependencies
+        run: python -m pip install --upgrade pip build
+
+      - name: Build package
+        run: python -m build --sdist --wheel
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      url: https://pypi.org/p/xhermes
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+xarray>=0.18.0
+xbout

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
+
 # Utility function to read the README file.
 # Used for the long_description.
 def read(fname):
@@ -18,7 +19,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Intended Audience :: Education",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache License",
+        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     description="Analyse data from Hermes-3 simulations using xarray",
     license="Apache",
     long_description=read("README.md"),
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Adds a GitHub workflow for publishing to PyPI.

Details:
-  A GitHub release triggers the workflow.
- The PyPI version number is set automatically from setup.py.
- It's **up to the releaser to ensure the release label / git tag is consistent with the version in setup.py** (couldn't find an easy way to enforce this automatically...)
- The 'pypi' GitHub environment is used to restrict when the "publish" step is allowed to run.
  - These restrictions are repo-level settings, and can be changed later if necessary.
  - Current restriction: the git tag associated with the release must match the pattern v[0-9]\*.[0-9]\*.[0-9]\* (else the publish step will fail).
  - More details on 'trusted publishing' for PyPI [here](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing).
- I've registered xhermes as a "pending project" on PyPI:
![image](https://github.com/user-attachments/assets/3bcb5be1-cc74-4305-b65e-9000a0419e99)
- I've tested the workflow using [TestPyPI](https://test.pypi.org/project/xhermes)
`pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple xhermes`

---

Other possible options:
- Use the release label to set the PyPI version instead. Doesn't gain anything, imho; one would still need to keep the version in setup.py in sync manually.
- Allow the workflow to be triggered manually. Can't think of any reason to do this, but it's easy to add if necessary.