### PR TITLE
Bugfix to `remove_guards()`

### DIFF
--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -617,8 +617,6 @@ class HypnotoadGrid:
         if m["MXG"] == 0 and m["MYG"] == 0:
             raise RuntimeError("X and Y guards already removed")
 
-        selector_yguards = selector_poloidal(self, "yguards")
-        selector_xdomain = selector_radial(self, "domain")
 
         for key in new.keys():
             item = new[key]
@@ -628,18 +626,22 @@ class HypnotoadGrid:
                     # If 2D array, remove radial and poloidal guards
                     if len(item.shape) == 2:
                         if m["MXG"] != 0:
+                            selector_xdomain = selector_radial(self, "domain")
                             item = item[selector_xdomain, :]
 
                         if m["MYG"] != 0:
+                            selector_yguards = selector_poloidal(self, "yguards")
                             item = np.delete(item, selector_yguards, axis=1)
 
                     # If 1D array matching radial size, remove radial guards
                     if m["MXG"] != 0:
+                        selector_xdomain = selector_radial(self, "domain")
                         if len(item.shape) == 1 and item.shape[0] == new["nx"]:
                             item = item[slice(2, -2)]
 
                     # If 1D array matching poloidal size, remove poloidal guards
                     if m["MYG"] != 0:
+                        selector_yguards = selector_poloidal(self, "yguards")
                         if len(item.shape) == 1 and item.shape[0] == new["ny"]:
                             item = np.delete(item, selector_yguards, axis=0)
 

--- a/xhermes/load.py
+++ b/xhermes/load.py
@@ -617,6 +617,7 @@ class HypnotoadGrid:
         if m["MXG"] == 0 and m["MYG"] == 0:
             raise RuntimeError("X and Y guards already removed")
 
+        selector_xdomain = selector_radial(self, "domain")
 
         for key in new.keys():
             item = new[key]
@@ -626,7 +627,6 @@ class HypnotoadGrid:
                     # If 2D array, remove radial and poloidal guards
                     if len(item.shape) == 2:
                         if m["MXG"] != 0:
-                            selector_xdomain = selector_radial(self, "domain")
                             item = item[selector_xdomain, :]
 
                         if m["MYG"] != 0:
@@ -635,7 +635,6 @@ class HypnotoadGrid:
 
                     # If 1D array matching radial size, remove radial guards
                     if m["MXG"] != 0:
-                        selector_xdomain = selector_radial(self, "domain")
                         if len(item.shape) == 1 and item.shape[0] == new["nx"]:
                             item = item[slice(2, -2)]
 


### PR DESCRIPTION
Only call the selector functions within if statements so that we ensure that the "domain" and "yguards" selector labels exist. This avoids a bug where `selector_poloidal(self, "yguards")` was called where m["MYG"] = 0, so the "yguards" label was an invalid selection, raising a `ValueError: Unknown poloidal selection yguards`.

This change may not be necessary for the `selector_radial()`.